### PR TITLE
Mouse position undefined on first load

### DIFF
--- a/src/triangle.js
+++ b/src/triangle.js
@@ -33,9 +33,17 @@ Triangle.prototype.draw = function (ctx, mousePosition) {
 };
 
 Triangle.prototype.getColour = function(mousePosition) {
-    var difference = this.getMouseDistance(this.center, mousePosition);
-    difference = difference > 100 ? 100 : difference;
-    difference = 100 - difference;
+
+    var difference = 0;
+
+    // Check if mousePosition has been defined before trying to use it to determine the colour
+    if (typeof mousePosition.x !== 'undefined' && typeof mousePosition.y !== 'undefined') {
+
+        difference = this.getMouseDistance(this.center, mousePosition);
+        difference = difference > 100 ? 100 : difference;
+        difference = 100 - difference;
+    }
+
     return this.changeColour(this.colour, this.hoverColour, difference);
 };
 


### PR DESCRIPTION
On first load the `mousePosition` objects `x` and `y` properties are `undefined` causing the difference variable to be set to `NaN` which meant all the triangles are rendered black 
