### PR TITLE
Colour option format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ new TriangleBackground(
 
 ## Option Reference
 
-```
+```Javascript
 options: {
-    color: []            // Specify the colours to use for the triangles, must be an array, defaults to a selection of greys
+    color: []            // Specify the colours to use for the triangles, must be an array of hexadecimal style colours, defaults to a selection of greys
 }
 ```
 


### PR DESCRIPTION
Just added a note in the README that the colours have to be in hexadecimal format
